### PR TITLE
allow j-test to be used for values as well as tests

### DIFF
--- a/lib/Test/Deep/JType.pm
+++ b/lib/Test/Deep/JType.pm
@@ -116,6 +116,14 @@ sub jfalse { $FALSE }
 {
   package Test::Deep::JType::jstr;
 
+  use overload
+    '""'    => sub {
+      Carp::confess("can't use valueless jstr() as a string")
+        unless defined ${ $_[0] };
+      return ${ $_[0] };
+    },
+    fallback => 1;
+
   BEGIN { our @ISA = 'JSON::Typist::String'; }
   sub TO_JSON {
     Carp::confess("can't use valueless jstr() test as JSON data")
@@ -134,6 +142,14 @@ sub jfalse { $FALSE }
 {
   package Test::Deep::JType::jnum;
 
+  use overload
+    '0+'    => sub {
+      Carp::confess("can't use valueless jnum() as a number")
+        unless defined ${ $_[0] };
+      return ${ $_[0] };
+    },
+    fallback => 1;
+
   BEGIN { our @ISA = 'JSON::Typist::Number'; }
   sub TO_JSON {
     Carp::confess("can't use valueless jnum() test as JSON data")
@@ -151,6 +167,14 @@ sub jfalse { $FALSE }
 
 {
   package Test::Deep::JType::jbool;
+
+  use overload
+    'bool'    => sub {
+      Carp::confess("can't use valueless jbool() as a bool")
+        unless defined ${ $_[0] };
+      return ${ $_[0] };
+    },
+    fallback => 1;
 
   sub TO_JSON {
     Carp::confess("can't use valueless jbool() test as JSON data")

--- a/t/wrapped.t
+++ b/t/wrapped.t
@@ -113,6 +113,18 @@ subtest "jtype routines for serialization" => sub {
     $struct,
     "jtype tests serialize to self-match",
   );
+
+  for my $test (
+    [ jnum  => jnum()   ],
+    [ jstr  => jstr()   ],
+    [ jbool => jbool()  ],
+  ) {
+    my ($desc, $obj) = @$test;
+    my $lived = eval { $json->encode({ value => $obj }); 1 };
+    my $error = $@;
+    ok(! $lived, "can't serialize a $desc that has no value");
+    like($error, qr/valueless $desc/, "...and we get the expected error");
+  }
 };
 
 done_testing;


### PR DESCRIPTION
With this branch, `jnum` and friends can be used to get JSON-serializable values that also work as test inputs for `jnum`.  So you can write:

```perl
my $req = [ getFoos => { ids => [ jstr(1) ] } ];
my $round_trip = decode_json( encode_json( $req ) );

jcmp_deeply($req->[1]{ids}[0], jstr());
jcmp_deeply($round_trip->[1]{ids}[0], jstr());
```

This relies on rjbs/Test-Deep#52 to work.