### PR TITLE
Fix output of $got in failures when $got is a string overloaded object

### DIFF
--- a/lib/Test/Deep/JType.pm
+++ b/lib/Test/Deep/JType.pm
@@ -129,7 +129,12 @@ sub jfalse { $FALSE }
   sub descend
   {
     my $self = shift;
-    my $got = shift();
+    my $got = shift;
+
+    # Stringify what we got for test output purposes. Otherwise,
+    # string overloading won't be called on $got, and we'll end up
+    # with 'JSON::Typist::String=SCALAR(0x...) in our test output
+    $self->data->{got} = $got . "" if defined $got;
 
     # If either is undef but not both this is a failure where
     # as Test::Deep::String would just stringify the undef,

--- a/t/leaf-wrapper.t
+++ b/t/leaf-wrapper.t
@@ -5,6 +5,7 @@ use Test::Tester;
 use Test::More;
 use Test::Deep;
 use Test::Deep::JType;
+use JSON::Typist;
 
 {
   note("got undef, expect empty str");
@@ -66,6 +67,29 @@ use Test::Deep::JType;
   like(
     $results[0]->{diag},
     qr/got \s* : \s* '' \s* expect \s* : \s* undef/x,
+    'diag is right'
+  );
+}
+
+
+{
+  note("ensure JSON::Typist values stringify right on failure");
+  my ($premature, @results) = run_tests(
+    sub {
+      jcmp_deeply(
+        JSON::Typist->apply_types({ u => "cat" }),
+        { u => "dog" },
+        "cat vs dog"
+      );
+    },
+  );
+
+  is($premature, '', 'no early diag');
+  is($results[0]->{ok}, 0, 'test failed');
+
+  like(
+    $results[0]->{diag},
+    qr/got \s* : \s* 'cat' \s* expect \s* : \s* 'dog'/x,
     'diag is right'
   );
 }


### PR DESCRIPTION
  jcmp_deeply(
    JSON::Typist->apply_types({ x => "cat" }),
    { x => "dog" },
    "ok!"
  );

would diag:

     got : JSON::Typist::String=SCALAR(0xasdfasf)
  expect : 'dog'

To fix it we need to do what Test::Deep::String does (which we
were more or less replacing), which is to stringify the given
input value and store that in our data for output.